### PR TITLE
Fixed conflicts between the two types of Profile

### DIFF
--- a/BM_mods/mods/betmode/Betmode.cs
+++ b/BM_mods/mods/betmode/Betmode.cs
@@ -16,13 +16,13 @@ namespace BM_RCON.mods.betmode
         {
             Thread.Sleep(160);
             rcon.SendRequest(requestType, body);
-            Console.WriteLine("");
+            //Console.WriteLine("");
         }
 
         private lib.RCON_Event receiveEvt(lib.BM_RCON rcon)
         {
             lib.RCON_Event evt = rcon.ReceiveEvent();
-            Console.WriteLine("");
+            //Console.WriteLine("");
             return evt;
         }
         static int Main(string[] args)
@@ -186,8 +186,8 @@ namespace BM_RCON.mods.betmode
                             break;
 
                         case lib.EventType.player_disconnect:
-                            { 
-                                Profile profile_disconnect = createProfile(json_obj.Profile);
+                            {
+                                Profile profile_disconnect = createProfile(json_obj.Profile.ToString());
                                 int index = indexPlayerGivenProfile(connected_players, profile_disconnect);
                                 int null_index = indexFirstNull(disconnected_players);
 
@@ -258,9 +258,9 @@ namespace BM_RCON.mods.betmode
             return index;
         }
 
-        private Profile createProfile(dynamic profile)
+        private Profile createProfile(string full_profile)
         {
-            return createProfile((string)profile.ProfileID, (string)profile.StoreID);
+            return new Profile(full_profile);
         }
 
         private Profile createProfile(string profileID, string storeID)
@@ -277,6 +277,7 @@ namespace BM_RCON.mods.betmode
             {
                 if (player == null)
                 {
+                    Console.WriteLine("");
                     return;
                 }
                 Console.Write("{0}, ", player.Name);

--- a/BM_mods/mods/betmode/Profile.cs
+++ b/BM_mods/mods/betmode/Profile.cs
@@ -8,11 +8,18 @@ namespace BM_RCON.mods.betmode
     {
         string profileID;
         string storeID;
+        string profile;
 
         public Profile(string profileID, string storeID)
         {
             this.profileID = profileID;
             this.storeID = storeID;
+            this.profile = $"{{ \"ProfileID\": \"{profileID}\", \"StoreID:\" \"{storeID}\" }}";
+        }
+
+        public Profile(string profile)
+        {
+            this.profile = profile;
         }
 
         public string ProfileID
@@ -31,9 +38,17 @@ namespace BM_RCON.mods.betmode
             }
         }
 
+        public string FullProfile
+        {
+            get
+            {
+                return this.profile;
+            }
+        }
+
         public bool Equals(Profile profile)
         {
-            return (this.profileID.Equals(profile.ProfileID)) && (this.storeID.Equals(profile.StoreID));
+            return this.FullProfile.Equals(profile.FullProfile);
         }
     }
 }

--- a/BM_mods/mods/betmode/Profile.cs
+++ b/BM_mods/mods/betmode/Profile.cs
@@ -14,7 +14,7 @@ namespace BM_RCON.mods.betmode
         {
             this.profileID = profileID;
             this.storeID = storeID;
-            this.profile = $"{{ \"ProfileID\": \"{profileID}\", \"StoreID:\" \"{storeID}\" }}";
+            this.profile = $"{{ \"ProfileID\": \"{profileID}\", \"StoreID\": \"{storeID}\" }}";
         }
 
         public Profile(string profile)


### PR DESCRIPTION
What I call a **full profile** is a string composed of a **ProfileID** and a **StoreID**.   
In most events, there is a key **Profile** containing a full profile.  
In the event player_connect, there is a key **Profile** which actually is a **ProfileID** and a key **Store** which is a **StoreID**.

The goal of this pull request is to handle more easily the two types of profile and to avoid conflicts between them.

Profile class:
- Added new constructor to create profile from a single string corresponding to a full profile
- Updated constructor created from a profileID and a storeID to manually create a full profile
- Added a getter for the full profile -> FullProfile
- Updated Equals method

  
Betmode class:
- Updated createProfile which used dynamic parameter to string parameter
- Updated createProfile to use the new constructor
- Updated player_disconnect event to give the full profile as string instead of an object