### PR TITLE
player_death event

### DIFF
--- a/BM_mods/mods/betmode/Betmode.cs
+++ b/BM_mods/mods/betmode/Betmode.cs
@@ -216,11 +216,21 @@ namespace BM_RCON.mods.betmode
                                 Player player = connected_players[index];
 
                                 player.IsAlive = true;
-                                logger.LogInfo($"{player.Name} spawned.");
+                                logger.LogInfo($"{player.Name} spawned. ({player.IsAlive})");
+                            }
+                            break;
+
+                        case lib.EventType.player_death:
+                            {
+                                Profile player_profile = createProfile(json_obj.VictimProfile.ToString());
+                                int index = indexPlayerGivenProfile(connected_players, player_profile);
+                                Player player = connected_players[index];
+
+                                player.IsAlive = false;
+                                logger.LogInfo($"{player.Name} just died. ({player.IsAlive})");
                             }
                             break;
                     }
-
                 }
                 amout_of_games++;
             }

--- a/BM_mods/mods/betmode/Betmode.cs
+++ b/BM_mods/mods/betmode/Betmode.cs
@@ -228,6 +228,11 @@ namespace BM_RCON.mods.betmode
 
                                 player.IsAlive = false;
                                 logger.LogInfo($"{player.Name} just died. ({player.IsAlive})");
+
+                                if (bets[current_bet] != null)
+                                {
+                                    bets[current_bet].UpdateDeadPlayer(player);
+                                }
                             }
                             break;
                     }

--- a/BM_mods/mods/betmode/README.md
+++ b/BM_mods/mods/betmode/README.md
@@ -12,11 +12,11 @@
 	- [x] Set the Player as dead
 	- [x] Update the Bet (if one) with the Player
 	- [x] Move the Player from connected_players to disconnected_players
-- [ ] player_spawn:
-	- [ ] Set the Player as alive
-- [ ] player_death:
-	- [ ] Set the Player as dead
-	- [ ] Update the Bet (if one) with the Player
+- [x] player_spawn:
+	- [x] Set the Player as alive
+- [x] player_death:
+	- [x] Set the Player as dead
+	- [x] Update the Bet (if one) with the Player
 - [ ] survival_get_vice:
 	- [ ] Get profile and new vice
 	- [ ] Search for the Player with the corresponding profile


### PR DESCRIPTION
- updated README for betmode for player_spawn and player_death
- when player_death event is caught:
    - set the player as dead
    - update the current bet if one with the dead player