### PR TITLE
Fix check for player or bot on existing events

### DIFF
--- a/BM_mods/mods/betmode/Betmode.cs
+++ b/BM_mods/mods/betmode/Betmode.cs
@@ -211,8 +211,19 @@ namespace BM_RCON.mods.betmode
 
                         case lib.EventType.player_spawn:
                             {
-                                Profile player_profile = createProfile(json_obj.Profile.ToString());
-                                int index = indexPlayerGivenProfile(connected_players, player_profile);
+                                Profile profile = createProfile(json_obj.Profile.ToString());
+                                if (profile.EqualsBotProfile())
+                                {
+                                    break;
+                                }
+                                int index = indexPlayerGivenProfile(connected_players, profile);
+                                if (index == -1)
+                                {
+                                    /* FIXME */
+                                    // create Player & Profile from a player already in the server
+                                    // when rcon client connected
+                                    break;
+                                }
                                 Player player = connected_players[index];
 
                                 player.IsAlive = true;
@@ -222,8 +233,19 @@ namespace BM_RCON.mods.betmode
 
                         case lib.EventType.player_death:
                             {
-                                Profile player_profile = createProfile(json_obj.VictimProfile.ToString());
-                                int index = indexPlayerGivenProfile(connected_players, player_profile);
+                                Profile profile = createProfile(json_obj.VictimProfile.ToString());
+                                if (profile.EqualsBotProfile())
+                                {
+                                    break;
+                                }
+                                int index = indexPlayerGivenProfile(connected_players, profile);
+                                if (index == -1)
+                                {
+                                    /* FIXME */
+                                    // create Player & Profile from a player already in the server
+                                    // when rcon client connected
+                                    break;
+                                }
                                 Player player = connected_players[index];
 
                                 player.IsAlive = false;

--- a/BM_mods/mods/betmode/Profile.cs
+++ b/BM_mods/mods/betmode/Profile.cs
@@ -50,5 +50,10 @@ namespace BM_RCON.mods.betmode
         {
             return this.FullProfile.Equals(profile.FullProfile);
         }
+
+        public bool EqualsBotProfile()
+        {
+            return this.FullProfile.Equals("{ \"ProfileID\": \"\", \"StoreID\": \"-1\" }");
+        }
     }
 }


### PR DESCRIPTION
- method EqualsBotProfile in Profile.cs to check if current Profile is one of a bot
- For events player_death & player_spawn, check if player is a bot and if he already exists